### PR TITLE
Fixed build failure when building with VS 2015

### DIFF
--- a/PmipMyCallStack.csproj
+++ b/PmipMyCallStack.csproj
@@ -4,6 +4,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">11.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <VSSDK140Install Condition="'$(VSSDK140Install)' == ''">$(MSBuildProgramFiles32)\Microsoft Visual Studio 14.0\VSSDK\</VSSDK140Install>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -76,7 +77,7 @@
   <PropertyGroup>
     <VsdConfigOutput>$(OutputPath)\PmipMyCallStack.vsdconfig</VsdConfigOutput>
   </PropertyGroup>
-  <Target Name="IncludeVsdConfig" BeforeTargets="AssignTargetPaths;GetVSIXSourceItems" Condition="$(VSTarget) != '10.0'">
+  <Target Name="IncludeVsdConfig" BeforeTargets="GetVSIXSourceItems" Condition="$(VSTarget) != '10.0'">
     <ItemGroup>
       <Content Include="$(VsdConfigOutput)">
         <IncludeInVSIX>true</IncludeInVSIX>


### PR DESCRIPTION
I had to remove `AssignTargetPaths` from `BeforeTargets` on the `IncludeVsdConfig` target or the `.vsdconfig` isn't generated. Also, sets `VSSDK140Install` if not already defined.
