### PR TITLE
Alternate method of finding the mono_pmip symbol which also works on 64-bit processes

### DIFF
--- a/PmipRunner.cs
+++ b/PmipRunner.cs
@@ -61,17 +61,13 @@ namespace PmipMyCallStack
 
 			foreach (var module in this._frame.RuntimeInstance.GetModuleInstances())
 			{
-				if (module is DkmNativeModuleInstance)
-				{
-					DkmNativeInstructionAddress address = ((DkmNativeModuleInstance) module).FindExportName("mono_pmip", true);
-					if (address != null)
-					{
-						PmipFunctionDataItem item = new PmipFunctionDataItem { PmipFunction = "0x" + address.CPUInstructionPart.InstructionPointer.ToString("X") };
-						pmipFunction = item;
-						_stackContext.SetDataItem(DkmDataCreationDisposition.CreateAlways, item);
-						return true;
-					}
-				}
+				var address = (module as DkmNativeModuleInstance)?.FindExportName("mono_pmip", IgnoreDataExports: true);
+				if (address == null)
+					continue;
+				var item = new PmipFunctionDataItem { PmipFunction = "0x" + address.CPUInstructionPart.InstructionPointer.ToString("X") };
+				pmipFunction = item;
+				_stackContext.SetDataItem(DkmDataCreationDisposition.CreateAlways, item);
+				return true;
 			}
 
 			return false;


### PR DESCRIPTION
When debugging 64-bit processes VS can not lookup the `mono_pmip` symbol in the JIT frame's context. This patch enumerates all loaded modules and tries DkmNativeModuleInstance.FindExportName("mono_pmip")` to find the address of the mono_pmip() function rather than using expression evaluation. This method has been validated to work with 32-bit and 64-bit processes.
